### PR TITLE
Doubled DEMO_STACK_SIZE

### DIFF
--- a/firmware/src/azure_rtos_demo/sample_netx_duo.c
+++ b/firmware/src/azure_rtos_demo/sample_netx_duo.c
@@ -12,7 +12,7 @@
 /* Define demo stack size.   */
 
 #ifndef DEMO_STACK_SIZE
-#define DEMO_STACK_SIZE         2048
+#define DEMO_STACK_SIZE         4096
 #endif
 
 #ifndef DEMO_THREAD_PRIORITY


### PR DESCRIPTION
Program would crash pretty regularly with DEMO_STACK_SIZE = 2048 when using X.509 authentication, so now it has been doubled up to 4096 bytes